### PR TITLE
Adding PreviousButton to layout

### DIFF
--- a/src/components/PreviousButton/PreviousButton.js
+++ b/src/components/PreviousButton/PreviousButton.js
@@ -1,0 +1,61 @@
+import React from "react";
+import injectSheet from "react-jss";
+import PropTypes from "prop-types";
+import Button from "material-ui/Button";
+import Link from "gatsby-link";
+import ArrowBackIcon from "material-ui-icons/ArrowBack";
+
+const styles = theme => ({
+  previousButton: {
+    position: "absolute",
+    left: "108px",
+    top: "calc(100vh - 114px)",
+    margin: "28px -28px 0 0",
+    transition: ".5s ease",
+    ".home &": {
+      left: "50%"
+    },
+    ".sidebar &": {
+      transform: "translate3D(220px,0,0)"
+    },
+    [`@media (min-width: ${theme.mediaQueryTresholds.M}px)`]: {
+      left: "118px",
+      top: "calc(100vh - 124px)"
+    },
+    [`@media (min-width: ${theme.mediaQueryTresholds.L}px)`]: {
+      left: "128px",
+      top: "calc(100vh - 134px)"
+    },
+    "@media all and (-ms-high-contrast:none)": {
+      transition: 0
+    }
+  }
+});
+
+const PreviousButton = props => {
+  const { classes, topOffset, to } = props;
+
+  return (
+    <div className={classes.previousButton} style={{ top: `${topOffset}` }} id="previousButton">
+      <Button
+        variant="fab"
+        component={Link}
+        to={to}
+        color="primary"
+        aria-label="previous"
+        className={classes.button}
+        title="Previous"
+      >
+        <ArrowBackIcon />
+      </Button>
+    </div>
+  );
+};
+
+PreviousButton.propTypes = {
+  classes: PropTypes.object.isRequired,
+  topOffset: PropTypes.string.isRequired,
+  to: PropTypes.string.isRequired
+};
+
+export default injectSheet(styles)(PreviousButton);

--- a/src/components/PreviousButton/index.js
+++ b/src/components/PreviousButton/index.js
@@ -1,0 +1,1 @@
+export { default } from "./PreviousButton";

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -16,6 +16,7 @@ import { timeoutThrottlerHandler } from "../utils/helpers";
 
 import Sidebar from "../components/Sidebar";
 import NextButton from "../components/NextButton/";
+import PreviousButton from "../components/PreviousButton/";
 import SidebarButton from "../components/Sidebar/SidebarButton";
 
 class Layout extends React.Component {
@@ -31,7 +32,8 @@ class Layout extends React.Component {
 
   state = {
     nextButtonTopOffset: "",
-    toForNextButton: ""
+    toForNextButton: "",
+    toForPreviousButton: ""
   };
 
   timeouts = {};
@@ -50,6 +52,7 @@ class Layout extends React.Component {
   componentDidUpdate(prevProps, prevState) {
     if (this.props.screenSequence !== prevProps.screenSequence) {
       this.setToForNextButton();
+      this.setToForPreviousButton();
     }
 
     if (this.props.location.pathname !== prevProps.location.pathname) {
@@ -59,6 +62,7 @@ class Layout extends React.Component {
         this.setState({ nextButtonTopOffset: "" });
       }
       this.setToForNextButton();
+      this.setToForPreviousButton();
     }
   }
 
@@ -134,6 +138,25 @@ class Layout extends React.Component {
     ___loader.enqueue(to);
   }
 
+  setToForPreviousButton() {
+    const currentScreen = this.props.location.pathname;
+    const sequence = this.props.screenSequence;
+
+    const currentScreenIndex = sequence.findIndex(el => el.slug === currentScreen);
+    const toIndex = currentScreenIndex - 1;
+
+    const to = toIndex < 0 ? "/" : sequence[toIndex].slug;
+
+    this.setState({ toForPreviousButton: to });
+
+    // because we dynamicaly changing a 'to' parameter of the PreviousButton's gatsby-link component
+    // we have to manualy do the job which in usual circumstances gatsby-link does for us automaticaly,
+    // prefetch assets for the next path
+
+    // eslint-disable-next-line no-undef
+    ___loader.enqueue(to);
+  }
+
   sidebarLinkOnClick = e => {
     e.preventDefault();
     const to = e.target.getAttribute("href");
@@ -148,6 +171,16 @@ class Layout extends React.Component {
     this.props.setSidebarVisible(this.props.sidebarVisible ? false : true);
   };
 
+  renderPreviousButton() {
+    // Just render Previous button if you're not in the Home Screen
+    return location.pathname !== "/" ? (
+      <PreviousButton
+        topOffset={this.state.nextButtonTopOffset}
+        to={this.state.toForPreviousButton}
+      />
+    ) : null;
+  }
+
   render() {
     const { location, screenSequence, sidebarVisible } = this.props;
 
@@ -160,6 +193,7 @@ class Layout extends React.Component {
         >
           {this.props.children()}
           <Sidebar screenSequence={screenSequence} onClick={this.sidebarLinkOnClick} />
+          {this.renderPreviousButton()}
           <NextButton topOffset={this.state.nextButtonTopOffset} to={this.state.toForNextButton} />
           <SidebarButton onClick={this.sidebarButtonOnClick} sidebarVisible={sidebarVisible} />
         </div>


### PR DESCRIPTION
This PR just creates a PreviousButton to the layout.

Changes:

- Created the `PreviousButton` component analogous from `NextButton`. Pretty similar, just changing the icon and the `right` css properties to `left`. I don't know if it was better to merge them into just 1 `Button` component and avoid code duplications though, diferentiating them with a new prop like `orientation` or `type`.  Anyway... maybe this could stay to the next increment of this =)

- Added `PreviousButton` to `layout/index.js`.
  - Created `this.setToForPreviousButton()` from analogous from `this.setToForNextButton()`
  - Anywhere using `this.setToForNextButton()`, calling the new `this.setToForPreviousButton()`
  - Created `renderPreviousButton` function, which controlls when the previous button must... duh, be rendered (anywhere, except on the Home/first page)

There it is. Any thoughts on this?